### PR TITLE
Switch to socketio_v4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,8 @@ platformdirs==3.5.1
 pylint==2.17.4
 pyproject_hooks==1.0.0
 pyright==1.1.313
-python-engineio==3.14.2
-python-socketio==4.6.1
+python-engineio-v3==3.14.2
+python-socketio-v4==4.6.1
 regex==2023.6.3
 six==1.16.0
 toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     install_requires=[
         "aiohttp",
         "netifaces",
-        "python-socketio>=4.0,<5.0",
-        "python-engineio>=3.0,<4.0"
+        "python-socketio-v4",
+        "python-engineio-v3"
     ],
     python_requires=">=3.8",
 )

--- a/sisyphus_control/transport.py
+++ b/sisyphus_control/transport.py
@@ -4,7 +4,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Type
 import aiohttp
 import asyncio
 import json
-import socketio
+import socketio_v4 as socketio
 
 TransportCallback = Callable[[Optional[List[Dict[str, Any]]]], Awaitable[None]]
 


### PR DESCRIPTION
socketio_v4 is a fork of socketio to avoid
conflicting with the socketio namespace

https://pypi.org/project/python-socketio-v4/

fixes #6